### PR TITLE
Don't getting rid of file extension process when input path is directory

### DIFF
--- a/Popstation/Popstation.cs
+++ b/Popstation/Popstation.cs
@@ -39,8 +39,14 @@ namespace Popstation
             var code = convertInfo.MainGameID;
             var region = convertInfo.MainGameRegion;
 
+            var originalFilename = convertInfo.OriginalFilename;
+            if (Directory.Exists(convertInfo.OriginalPath)) 
+            {
+                originalFilename += ".dir";
+            }
+
             var outputFilename = GetFilename(convertInfo.FileNameFormat,
-                convertInfo.OriginalFilename,
+                originalFilename,
                 code,
                 code,
                 title,


### PR DESCRIPTION

Here is `Foo Ver.Bar (Japan)` directory.

```
Foo Ver.Bar (Japan)
  - Foo Ver.Bar (Japan) (Track 01).bin
  - Foo Ver.Bar (Japan) (Track 02).bin
  - Foo Ver.Bar (Japan) (Track 03).bin
  - Foo Ver.Bar (Japan) (Track 04).bin
  - Foo Ver.Bar (Japan).cue
```

Running

```
PSXPackager -o /path/to/PBP  -i /path/to/Foo\ Ver\.Bar\ \(Japan\)
```

Rsult is stored to `/path/to/PBP/Foo Ver.pbp`. But it should be `/path/to/PBP/Foo Ver.Bar (Japan).pbp`


This fix makes it so.